### PR TITLE
Removes unused and outdated Hoek dependency which had identified NSP …

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,6 @@
 const _ = require('lodash');
 const fs = require('fs');
 const path = require('path');
-const Hoek = require('hoek');
 const handlebars = require('handlebars');
 
 const Joi = require('joi');

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,7 @@
   "name": "windshieldjs",
   "version": "3.0.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "abbrev": {
       "version": "1.0.9",
@@ -12,7 +13,12 @@
     "align-text": {
       "version": "0.1.4",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc="
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
     },
     "amdefine": {
       "version": "1.0.1",
@@ -38,7 +44,10 @@
       "version": "1.0.9",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
     },
     "array-differ": {
       "version": "1.0.0",
@@ -49,7 +58,10 @@
       "version": "1.0.2",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -92,13 +104,27 @@
     "boom": {
       "version": "3.0.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/boom/-/boom-3.0.0.tgz",
-      "integrity": "sha1-z/hYy9AMZcEeanS0qdyQueO5BsQ="
+      "integrity": "sha1-z/hYy9AMZcEeanS0qdyQueO5BsQ=",
+      "requires": {
+        "hoek": "3.0.4"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "3.0.4",
+          "resolved": "https://repository.cars.com/artifactory/api/npm/npm/hoek/-/hoek-3.0.4.tgz",
+          "integrity": "sha1-Jorf9mu2aVxptHiaiLHghHw/MSM="
+        }
+      }
     },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "camelcase": {
       "version": "1.2.1",
@@ -110,18 +136,34 @@
       "version": "0.1.3",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
     },
     "chai": {
       "version": "3.5.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/chai/-/chai-3.5.0.tgz",
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.0.2",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
+      }
     },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
     },
     "circular-json": {
       "version": "0.3.1",
@@ -132,7 +174,10 @@
     "cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc="
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
     },
     "cli-width": {
       "version": "2.1.0",
@@ -144,6 +189,11 @@
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "optional": true,
+      "requires": {
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
@@ -185,6 +235,11 @@
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -196,13 +251,25 @@
           "version": "2.3.3",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
         }
       }
     },
@@ -216,12 +283,21 @@
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
+      "requires": {
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.2.14"
+      },
       "dependencies": {
         "lru-cache": {
           "version": "4.1.1",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/lru-cache/-/lru-cache-4.1.1.tgz",
           "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
         }
       }
     },
@@ -229,7 +305,10 @@
       "version": "1.0.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es5-ext": "0.10.23"
+      }
     },
     "dateformat": {
       "version": "2.0.0",
@@ -240,7 +319,10 @@
       "version": "2.6.8",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/debug/-/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "decamelize": {
       "version": "1.2.0",
@@ -253,6 +335,9 @@
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/deep-eql/-/deep-eql-0.1.3.tgz",
       "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
       "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      },
       "dependencies": {
         "type-detect": {
           "version": "0.1.1",
@@ -272,7 +357,16 @@
       "version": "2.2.2",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.1"
+      }
     },
     "diff": {
       "version": "1.4.0",
@@ -284,6 +378,10 @@
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/doctrine/-/doctrine-0.7.2.tgz",
       "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
       "dev": true,
+      "requires": {
+        "esutils": "1.1.6",
+        "isarray": "0.0.1"
+      },
       "dependencies": {
         "esutils": {
           "version": "1.1.6",
@@ -296,43 +394,80 @@
     "duplexer2": {
       "version": "0.0.2",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/duplexer2/-/duplexer2-0.0.2.tgz",
-      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds="
+      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+      "requires": {
+        "readable-stream": "1.1.14"
+      }
     },
     "es5-ext": {
       "version": "0.10.23",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/es5-ext/-/es5-ext-0.10.23.tgz",
       "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      }
     },
     "es6-iterator": {
       "version": "2.0.1",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/es6-iterator/-/es6-iterator-2.0.1.tgz",
       "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-symbol": "3.1.1"
+      }
     },
     "es6-map": {
       "version": "0.1.5",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
     },
     "es6-set": {
       "version": "0.1.5",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
     },
     "es6-symbol": {
       "version": "3.1.1",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23"
+      }
     },
     "es6-weak-map": {
       "version": "2.0.2",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -344,6 +479,13 @@
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/escodegen/-/escodegen-1.8.1.tgz",
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
+      "requires": {
+        "esprima": "2.7.3",
+        "estraverse": "1.9.3",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.2.0"
+      },
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
@@ -367,20 +509,35 @@
           "version": "0.3.0",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/levn/-/levn-0.3.0.tgz",
           "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2"
+          }
         },
         "optionator": {
           "version": "0.8.2",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/optionator/-/optionator-0.8.2.tgz",
           "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "deep-is": "0.1.3",
+            "fast-levenshtein": "2.0.6",
+            "levn": "0.3.0",
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2",
+            "wordwrap": "1.0.0"
+          }
         },
         "source-map": {
           "version": "0.2.0",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/source-map/-/source-map-0.2.0.tgz",
           "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         },
         "wordwrap": {
           "version": "1.0.0",
@@ -394,13 +551,54 @@
       "version": "3.6.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      }
     },
     "eslint": {
       "version": "1.10.3",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/eslint/-/eslint-1.10.3.tgz",
       "integrity": "sha1-+xmpGxPBWAgrvKKUsX2Xm8g1Ogo=",
       "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "debug": "2.6.8",
+        "doctrine": "0.7.2",
+        "escape-string-regexp": "1.0.5",
+        "escope": "3.6.0",
+        "espree": "2.2.5",
+        "estraverse": "4.2.0",
+        "estraverse-fb": "1.3.1",
+        "esutils": "2.0.2",
+        "file-entry-cache": "1.3.1",
+        "glob": "5.0.15",
+        "globals": "8.18.0",
+        "handlebars": "4.0.10",
+        "inquirer": "0.11.4",
+        "is-my-json-valid": "2.16.0",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.4.5",
+        "json-stable-stringify": "1.0.1",
+        "lodash.clonedeep": "3.0.2",
+        "lodash.merge": "3.3.2",
+        "lodash.omit": "3.1.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1",
+        "optionator": "0.6.0",
+        "path-is-absolute": "1.0.1",
+        "path-is-inside": "1.0.2",
+        "shelljs": "0.5.3",
+        "strip-json-comments": "1.0.4",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0",
+        "xml-escape": "1.0.0"
+      },
       "dependencies": {
         "cli-width": {
           "version": "1.1.1",
@@ -412,7 +610,22 @@
           "version": "0.11.4",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/inquirer/-/inquirer-0.11.4.tgz",
           "integrity": "sha1-geM3ToNhvq/y2XAWIG01nQsy+k0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "1.4.0",
+            "ansi-regex": "2.1.1",
+            "chalk": "1.1.3",
+            "cli-cursor": "1.0.2",
+            "cli-width": "1.1.1",
+            "figures": "1.7.0",
+            "lodash": "3.10.1",
+            "readline2": "1.0.1",
+            "run-async": "0.1.0",
+            "rx-lite": "3.1.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "through": "2.3.8"
+          }
         },
         "lodash": {
           "version": "3.10.1",
@@ -432,7 +645,11 @@
       "version": "4.2.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/esrecurse/-/esrecurse-4.2.0.tgz",
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
+      }
     },
     "estraverse": {
       "version": "4.2.0",
@@ -456,7 +673,11 @@
       "version": "0.3.5",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23"
+      }
     },
     "exit-hook": {
       "version": "1.1.1",
@@ -466,7 +687,11 @@
     "fancy-log": {
       "version": "1.3.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/fancy-log/-/fancy-log-1.3.0.tgz",
-      "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg="
+      "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+      "requires": {
+        "chalk": "1.1.3",
+        "time-stamp": "1.1.0"
+      }
     },
     "fast-levenshtein": {
       "version": "1.0.7",
@@ -477,25 +702,42 @@
     "figures": {
       "version": "1.7.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4="
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
+      }
     },
     "file-entry-cache": {
       "version": "1.3.1",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
       "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.2.2",
+        "object-assign": "4.1.1"
+      }
     },
     "flat-cache": {
       "version": "1.2.2",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/flat-cache/-/flat-cache-1.2.2.tgz",
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.1",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
     },
     "formatio": {
       "version": "1.1.1",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/formatio/-/formatio-1.1.1.tgz",
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "samsam": "1.1.2"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -513,13 +755,23 @@
       "version": "1.2.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
     },
     "glob": {
       "version": "5.0.15",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/glob/-/glob-5.0.15.tgz",
       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "globals": {
       "version": "8.18.0",
@@ -532,19 +784,38 @@
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      },
       "dependencies": {
         "glob": {
           "version": "7.1.2",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/glob/-/glob-7.1.2.tgz",
           "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         }
       }
     },
     "glogg": {
       "version": "1.0.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/glogg/-/glogg-1.0.0.tgz",
-      "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U="
+      "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+      "requires": {
+        "sparkles": "1.0.0"
+      }
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -562,6 +833,26 @@
       "version": "3.0.8",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/gulp-util/-/gulp-util-3.0.8.tgz",
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+      "requires": {
+        "array-differ": "1.0.0",
+        "array-uniq": "1.0.3",
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "dateformat": "2.0.0",
+        "fancy-log": "1.3.0",
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash._reescape": "3.0.0",
+        "lodash._reevaluate": "3.0.0",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.template": "3.6.2",
+        "minimist": "1.2.0",
+        "multipipe": "0.1.2",
+        "object-assign": "3.0.0",
+        "replace-ext": "0.0.1",
+        "through2": "2.0.3",
+        "vinyl": "0.5.3"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -576,83 +867,161 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw="
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs="
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
         },
         "through2": {
           "version": "2.0.3",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4="
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+          "requires": {
+            "readable-stream": "2.3.3",
+            "xtend": "4.0.1"
+          }
         }
       }
     },
     "gulplog": {
       "version": "1.0.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/gulplog/-/gulplog-1.0.0.tgz",
-      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U="
+      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+      "requires": {
+        "glogg": "1.0.0"
+      }
     },
     "handlebars": {
       "version": "4.0.10",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/handlebars/-/handlebars-4.0.10.tgz",
-      "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08="
+      "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
+      }
     },
     "hapi": {
       "version": "11.1.4",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/hapi/-/hapi-11.1.4.tgz",
       "integrity": "sha1-qAWI0XWh2UiazaD90T31oHZvVc4=",
       "dev": true,
+      "requires": {
+        "accept": "2.0.0",
+        "ammo": "2.0.0",
+        "boom": "3.0.0",
+        "call": "3.0.0",
+        "catbox": "7.0.0",
+        "catbox-memory": "2.0.1",
+        "cryptiles": "3.0.0",
+        "heavy": "4.0.0",
+        "hoek": "3.0.0",
+        "iron": "3.0.1",
+        "items": "2.0.0",
+        "joi": "7.0.0",
+        "kilt": "2.0.0",
+        "mimos": "3.0.0",
+        "peekaboo": "2.0.0",
+        "qs": "6.0.0",
+        "shot": "2.0.1",
+        "statehood": "3.0.0",
+        "subtext": "3.0.1",
+        "topo": "2.0.0"
+      },
       "dependencies": {
         "accept": {
           "version": "2.0.0",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/accept/-/accept-2.0.0.tgz",
           "integrity": "sha1-IZ/zxonoytxxmV5L2dtwRaOMNFk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "boom": "3.0.0",
+            "hoek": "3.0.0"
+          }
         },
         "ammo": {
           "version": "2.0.0",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/ammo/-/ammo-2.0.0.tgz",
           "integrity": "sha1-FNvfwfti19gmAgbTfkghkmXSS+g=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "boom": "3.0.0",
+            "hoek": "3.0.0"
+          }
         },
         "boom": {
           "version": "3.0.0",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/boom/-/boom-3.0.0.tgz",
           "integrity": "sha1-z/hYy9AMZcEeanS0qdyQueO5BsQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hoek": "3.0.0"
+          }
         },
         "call": {
           "version": "3.0.0",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/call/-/call-3.0.0.tgz",
           "integrity": "sha1-6VTpAzInH3qxJgtN4BjWjq+z8BE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "boom": "3.0.0",
+            "hoek": "3.0.0"
+          }
         },
         "catbox": {
           "version": "7.0.0",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/catbox/-/catbox-7.0.0.tgz",
           "integrity": "sha1-PUACQlj1az+YUemblXY+BrxjpEI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "boom": "3.0.0",
+            "hoek": "3.0.0",
+            "joi": "7.0.0"
+          }
         },
         "catbox-memory": {
           "version": "2.0.1",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/catbox-memory/-/catbox-memory-2.0.1.tgz",
           "integrity": "sha1-vfxec2RI/hbA/5FCfU2xGsNNk5Y=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hoek": "3.0.0"
+          }
         },
         "cryptiles": {
           "version": "3.0.0",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/cryptiles/-/cryptiles-3.0.0.tgz",
           "integrity": "sha1-4Uj7j2ZqhxKEPd9lwZZ2nR44eQw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "boom": "3.0.0"
+          }
         },
         "heavy": {
           "version": "4.0.0",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/heavy/-/heavy-4.0.0.tgz",
           "integrity": "sha1-ffqckK80PxaAaoxIootJmiPexHE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "boom": "3.0.0",
+            "hoek": "3.0.0",
+            "joi": "7.0.0"
+          }
         },
         "hoek": {
           "version": "3.0.0",
@@ -664,7 +1033,12 @@
           "version": "3.0.1",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/iron/-/iron-3.0.1.tgz",
           "integrity": "sha1-PdOxAKch0VubewM6DPTB4yZgPNM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "boom": "3.0.0",
+            "cryptiles": "3.0.0",
+            "hoek": "3.0.0"
+          }
         },
         "items": {
           "version": "2.0.0",
@@ -677,6 +1051,12 @@
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/joi/-/joi-7.0.0.tgz",
           "integrity": "sha1-fwpeVsCBiqvXpYNmp5GjgYwLY98=",
           "dev": true,
+          "requires": {
+            "hoek": "3.0.0",
+            "isemail": "2.0.0",
+            "moment": "2.10.6",
+            "topo": "2.0.0"
+          },
           "dependencies": {
             "isemail": {
               "version": "2.0.0",
@@ -696,13 +1076,20 @@
           "version": "2.0.0",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/kilt/-/kilt-2.0.0.tgz",
           "integrity": "sha1-igb2YkoUhHRBwQLDsS6e8Gr13fI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hoek": "3.0.0"
+          }
         },
         "mimos": {
           "version": "3.0.0",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/mimos/-/mimos-3.0.0.tgz",
           "integrity": "sha1-SygG4SXbvfcdmyzZ8LO0VsQDyCE=",
           "dev": true,
+          "requires": {
+            "hoek": "3.0.0",
+            "mime-db": "1.19.0"
+          },
           "dependencies": {
             "mime-db": {
               "version": "1.19.0",
@@ -728,49 +1115,88 @@
           "version": "2.0.1",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/shot/-/shot-2.0.1.tgz",
           "integrity": "sha1-pEpYcr/KTSr60NVz1eIZWLtNwA8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hoek": "3.0.0"
+          }
         },
         "statehood": {
           "version": "3.0.0",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/statehood/-/statehood-3.0.0.tgz",
           "integrity": "sha1-pJDgpzmG/ZlCFeT7xBSVwq6+BdM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "boom": "3.0.0",
+            "cryptiles": "3.0.0",
+            "hoek": "3.0.0",
+            "iron": "3.0.1",
+            "items": "2.0.0",
+            "joi": "7.0.0"
+          }
         },
         "subtext": {
           "version": "3.0.1",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/subtext/-/subtext-3.0.1.tgz",
           "integrity": "sha1-iBdgaPuBYqF2QyYzlHCWS9vhN8M=",
           "dev": true,
+          "requires": {
+            "boom": "3.0.0",
+            "content": "3.0.0",
+            "hoek": "3.0.0",
+            "pez": "2.0.1",
+            "qs": "6.0.0",
+            "wreck": "7.0.0"
+          },
           "dependencies": {
             "content": {
               "version": "3.0.0",
               "resolved": "https://repository.cars.com/artifactory/api/npm/npm/content/-/content-3.0.0.tgz",
               "integrity": "sha1-+xpmghRxLKPdGKTsuw9f5x+35s0=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "boom": "3.0.0"
+              }
             },
             "pez": {
               "version": "2.0.1",
               "resolved": "https://repository.cars.com/artifactory/api/npm/npm/pez/-/pez-2.0.1.tgz",
               "integrity": "sha1-WAV4vrF/GU03y4dN+8aHzM3omxE=",
               "dev": true,
+              "requires": {
+                "b64": "3.0.0",
+                "boom": "3.0.0",
+                "content": "3.0.0",
+                "hoek": "3.0.0",
+                "nigel": "2.0.0"
+              },
               "dependencies": {
                 "b64": {
                   "version": "3.0.0",
                   "resolved": "https://repository.cars.com/artifactory/api/npm/npm/b64/-/b64-3.0.0.tgz",
                   "integrity": "sha1-MrMhzdoLmzEMdi05OrqSAdjk8hc=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "hoek": "3.0.0"
+                  }
                 },
                 "nigel": {
                   "version": "2.0.0",
                   "resolved": "https://repository.cars.com/artifactory/api/npm/npm/nigel/-/nigel-2.0.0.tgz",
                   "integrity": "sha1-4lEYegUz6ufIIy99ejhlrkdorWk=",
                   "dev": true,
+                  "requires": {
+                    "hoek": "3.0.0",
+                    "vise": "2.0.0"
+                  },
                   "dependencies": {
                     "vise": {
                       "version": "2.0.0",
                       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/vise/-/vise-2.0.0.tgz",
                       "integrity": "sha1-eNaLZOdJXqWYqcJMby4GLk1XldY=",
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "hoek": "3.0.0"
+                      }
                     }
                   }
                 }
@@ -780,7 +1206,11 @@
               "version": "7.0.0",
               "resolved": "https://repository.cars.com/artifactory/api/npm/npm/wreck/-/wreck-7.0.0.tgz",
               "integrity": "sha1-jtUr2MIN4dApRr2QeP3LPEh6Gho=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "boom": "3.0.0",
+                "hoek": "3.0.0"
+              }
             }
           }
         },
@@ -788,14 +1218,20 @@
           "version": "2.0.0",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/topo/-/topo-2.0.0.tgz",
           "integrity": "sha1-MVya7bhoytW2FhWWPJ/Qm+kSwe0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hoek": "3.0.0"
+          }
         }
       }
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "has-flag": {
       "version": "1.0.0",
@@ -806,18 +1242,20 @@
     "has-gulplog": {
       "version": "0.1.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/has-gulplog/-/has-gulplog-0.1.0.tgz",
-      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4="
-    },
-    "hoek": {
-      "version": "3.0.1",
-      "resolved": "https://repository.cars.com/artifactory/api/npm/npm/hoek/-/hoek-3.0.1.tgz",
-      "integrity": "sha1-NRg0wUcxRfMSBQYD7yuL83CV/z8="
+      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+      "requires": {
+        "sparkles": "1.0.0"
+      }
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -832,7 +1270,22 @@
     "inquirer": {
       "version": "0.12.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/inquirer/-/inquirer-0.12.0.tgz",
-      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34="
+      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "2.1.0",
+        "figures": "1.7.0",
+        "lodash": "4.17.4",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
+      }
     },
     "is-buffer": {
       "version": "1.1.5",
@@ -842,13 +1295,22 @@
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-my-json-valid": {
       "version": "2.16.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -860,13 +1322,19 @@
       "version": "1.0.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.0"
+      }
     },
     "is-path-inside": {
       "version": "1.0.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
     },
     "is-property": {
       "version": "1.0.2",
@@ -878,7 +1346,10 @@
       "version": "1.0.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tryit": "1.0.3"
+      }
     },
     "isarray": {
       "version": "0.0.1",
@@ -901,6 +1372,22 @@
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/istanbul/-/istanbul-0.4.5.tgz",
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
+      "requires": {
+        "abbrev": "1.0.9",
+        "async": "1.5.2",
+        "escodegen": "1.8.1",
+        "esprima": "2.7.3",
+        "glob": "5.0.15",
+        "handlebars": "4.0.10",
+        "js-yaml": "3.4.5",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "once": "1.4.0",
+        "resolve": "1.1.7",
+        "supports-color": "3.2.3",
+        "which": "1.2.14",
+        "wordwrap": "1.0.0"
+      },
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
@@ -912,7 +1399,10 @@
           "version": "3.2.3",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         },
         "wordwrap": {
           "version": "1.0.0",
@@ -933,6 +1423,10 @@
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/jade/-/jade-0.26.3.tgz",
       "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
       "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
       "dependencies": {
         "commander": {
           "version": "0.6.1",
@@ -951,13 +1445,30 @@
     "joi": {
       "version": "7.0.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/joi/-/joi-7.0.0.tgz",
-      "integrity": "sha1-fwpeVsCBiqvXpYNmp5GjgYwLY98="
+      "integrity": "sha1-fwpeVsCBiqvXpYNmp5GjgYwLY98=",
+      "requires": {
+        "hoek": "3.0.4",
+        "isemail": "2.2.1",
+        "moment": "2.18.1",
+        "topo": "2.0.2"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "3.0.4",
+          "resolved": "https://repository.cars.com/artifactory/api/npm/npm/hoek/-/hoek-3.0.4.tgz",
+          "integrity": "sha1-Jorf9mu2aVxptHiaiLHghHw/MSM="
+        }
+      }
     },
     "js-yaml": {
       "version": "3.4.5",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/js-yaml/-/js-yaml-3.4.5.tgz",
       "integrity": "sha1-w0A3l98SuRhmV08t4jZG/oyvtE0=",
       "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "2.7.3"
+      },
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
@@ -971,7 +1482,10 @@
       "version": "1.0.1",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -988,7 +1502,10 @@
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "requires": {
+        "is-buffer": "1.1.5"
+      }
     },
     "lazy-cache": {
       "version": "1.0.4",
@@ -1000,7 +1517,11 @@
       "version": "0.2.5",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/levn/-/levn-0.2.5.tgz",
       "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
     },
     "lodash": {
       "version": "4.17.4",
@@ -1029,13 +1550,25 @@
       "version": "3.2.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
     },
     "lodash._baseclone": {
       "version": "3.3.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
       "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._arraycopy": "3.0.0",
+        "lodash._arrayeach": "3.0.0",
+        "lodash._baseassign": "3.2.0",
+        "lodash._basefor": "3.0.3",
+        "lodash.isarray": "3.0.4",
+        "lodash.keys": "3.1.2"
+      }
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -1046,13 +1579,22 @@
       "version": "3.0.3",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
       "integrity": "sha1-8sIEKWwqeOArOJCBtu3KyTPPYpw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._baseindexof": "3.1.0",
+        "lodash._cacheindexof": "3.0.2",
+        "lodash._createcache": "3.1.2"
+      }
     },
     "lodash._baseflatten": {
       "version": "3.1.4",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
       "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
     },
     "lodash._basefor": {
       "version": "3.0.3",
@@ -1092,13 +1634,21 @@
       "version": "3.1.1",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
       "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._bindcallback": "3.0.1",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash.restparam": "3.6.1"
+      }
     },
     "lodash._createcache": {
       "version": "3.1.2",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
       "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1"
+      }
     },
     "lodash._getnative": {
       "version": "3.9.1",
@@ -1120,7 +1670,11 @@
       "version": "3.0.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
       "integrity": "sha1-/2G5oBens699MObFPeKK+hm4dQo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basefor": "3.0.3",
+        "lodash.keysin": "3.0.8"
+      }
     },
     "lodash._reescape": {
       "version": "3.0.0",
@@ -1146,12 +1700,19 @@
       "version": "3.0.2",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
       "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._baseclone": "3.3.0",
+        "lodash._bindcallback": "3.0.1"
+      }
     },
     "lodash.escape": {
       "version": "3.2.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/lodash.escape/-/lodash.escape-3.2.0.tgz",
-      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg="
+      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+      "requires": {
+        "lodash._root": "3.0.1"
+      }
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -1167,7 +1728,12 @@
       "version": "3.2.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
       "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basefor": "3.0.3",
+        "lodash.isarguments": "3.1.0",
+        "lodash.keysin": "3.0.8"
+      }
     },
     "lodash.istypedarray": {
       "version": "3.0.6",
@@ -1178,25 +1744,57 @@
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo="
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
     },
     "lodash.keysin": {
       "version": "3.0.8",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
       "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
     },
     "lodash.merge": {
       "version": "3.3.2",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/lodash.merge/-/lodash.merge-3.3.2.tgz",
       "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._arraycopy": "3.0.0",
+        "lodash._arrayeach": "3.0.0",
+        "lodash._createassigner": "3.1.1",
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4",
+        "lodash.isplainobject": "3.2.0",
+        "lodash.istypedarray": "3.0.6",
+        "lodash.keys": "3.1.2",
+        "lodash.keysin": "3.0.8",
+        "lodash.toplainobject": "3.0.0"
+      }
     },
     "lodash.omit": {
       "version": "3.1.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/lodash.omit/-/lodash.omit-3.1.0.tgz",
       "integrity": "sha1-iX/jguZBPZrJfGH3jtHgV6AK+fM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._arraymap": "3.0.0",
+        "lodash._basedifference": "3.0.3",
+        "lodash._baseflatten": "3.1.4",
+        "lodash._bindcallback": "3.0.1",
+        "lodash._pickbyarray": "3.0.2",
+        "lodash._pickbycallback": "3.0.0",
+        "lodash.keysin": "3.0.8",
+        "lodash.restparam": "3.6.1"
+      }
     },
     "lodash.restparam": {
       "version": "3.6.1",
@@ -1206,18 +1804,37 @@
     "lodash.template": {
       "version": "3.6.2",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/lodash.template/-/lodash.template-3.6.2.tgz",
-      "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8="
+      "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash._basetostring": "3.0.1",
+        "lodash._basevalues": "3.0.0",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0",
+        "lodash.keys": "3.1.2",
+        "lodash.restparam": "3.6.1",
+        "lodash.templatesettings": "3.1.1"
+      }
     },
     "lodash.templatesettings": {
       "version": "3.1.1",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-      "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU="
+      "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+      "requires": {
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0"
+      }
     },
     "lodash.toplainobject": {
       "version": "3.0.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
       "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keysin": "3.0.8"
+      }
     },
     "lolex": {
       "version": "1.3.2",
@@ -1240,7 +1857,10 @@
       "version": "3.0.4",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
     },
     "minimist": {
       "version": "1.2.0",
@@ -1251,6 +1871,9 @@
       "version": "0.5.1",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
@@ -1264,12 +1887,27 @@
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/mocha/-/mocha-2.5.3.tgz",
       "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
       "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.11",
+        "growl": "1.9.2",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.1",
+        "supports-color": "1.2.0",
+        "to-iso-string": "0.0.2"
+      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "escape-string-regexp": {
           "version": "1.0.2",
@@ -1281,13 +1919,21 @@
           "version": "3.2.11",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/glob/-/glob-3.2.11.tgz",
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "minimatch": "0.3.0"
+          }
         },
         "minimatch": {
           "version": "0.3.0",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/minimatch/-/minimatch-0.3.0.tgz",
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
         },
         "ms": {
           "version": "0.7.1",
@@ -1317,7 +1963,10 @@
     "multipipe": {
       "version": "0.1.2",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/multipipe/-/multipipe-0.1.2.tgz",
-      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s="
+      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+      "requires": {
+        "duplexer2": "0.0.2"
+      }
     },
     "mute-stream": {
       "version": "0.0.5",
@@ -1328,7 +1977,10 @@
       "version": "3.0.6",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.9"
+      }
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -1343,7 +1995,10 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "onetime": {
       "version": "1.1.0",
@@ -1354,6 +2009,10 @@
       "version": "0.6.1",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "requires": {
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
@@ -1366,7 +2025,15 @@
       "version": "0.6.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/optionator/-/optionator-0.6.0.tgz",
       "integrity": "sha1-tj7Lvw4xX61LyYJ7Rdx7pFKE/LY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "1.0.7",
+        "levn": "0.2.5",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "0.0.3"
+      }
     },
     "os-homedir": {
       "version": "1.0.2",
@@ -1408,13 +2075,21 @@
       "version": "2.0.1",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
     },
     "pre-commit": {
       "version": "1.2.2",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/pre-commit/-/pre-commit-1.2.2.tgz",
       "integrity": "sha1-287g7p3nI15X95xW186UZBpp7sY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "spawn-sync": "1.0.15",
+        "which": "1.2.14"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -1436,12 +2111,23 @@
     "readable-stream": {
       "version": "1.1.14",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "string_decoder": "0.10.31"
+      }
     },
     "readline2": {
       "version": "1.0.1",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/readline2/-/readline2-1.0.1.tgz",
-      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU="
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "mute-stream": "0.0.5"
+      }
     },
     "repeat-string": {
       "version": "1.6.1",
@@ -1462,32 +2148,53 @@
     "restore-cursor": {
       "version": "1.0.1",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE="
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
     },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
     },
     "rimraf": {
       "version": "2.6.1",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
       "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      },
       "dependencies": {
         "glob": {
           "version": "7.1.2",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/glob/-/glob-7.1.2.tgz",
           "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         }
       }
     },
     "run-async": {
       "version": "0.1.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/run-async/-/run-async-0.1.0.tgz",
-      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k="
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "requires": {
+        "once": "1.4.0"
+      }
     },
     "rx-lite": {
       "version": "3.1.2",
@@ -1509,7 +2216,10 @@
       "version": "1.2.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
     },
     "shebang-regex": {
       "version": "1.0.0",
@@ -1533,7 +2243,13 @@
       "version": "1.17.7",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/sinon/-/sinon-1.17.7.tgz",
       "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "formatio": "1.1.1",
+        "lolex": "1.3.2",
+        "samsam": "1.1.2",
+        "util": "0.10.3"
+      }
     },
     "sinon-chai": {
       "version": "2.11.0",
@@ -1544,7 +2260,10 @@
     "source-map": {
       "version": "0.4.4",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/source-map/-/source-map-0.4.4.tgz",
-      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s="
+      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+      "requires": {
+        "amdefine": "1.0.1"
+      }
     },
     "sparkles": {
       "version": "1.0.0",
@@ -1555,7 +2274,11 @@
       "version": "1.0.15",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/spawn-sync/-/spawn-sync-1.0.15.tgz",
       "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.0",
+        "os-shim": "0.1.3"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -1566,22 +2289,36 @@
     "stream-conflict": {
       "version": "0.0.1",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/stream-conflict/-/stream-conflict-0.0.1.tgz",
-      "integrity": "sha1-ecACluAxpxmSg5nlzjEsdIIIGaE="
+      "integrity": "sha1-ecACluAxpxmSg5nlzjEsdIIIGaE=",
+      "requires": {
+        "diff": "1.4.0",
+        "gulp-util": "3.0.8",
+        "inquirer": "0.12.0",
+        "through2": "0.6.5"
+      }
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://repository.cars.com/artifactory/api/npm/npm/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
     },
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
-    "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://repository.cars.com/artifactory/api/npm/npm/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
-    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "strip-json-comments": {
       "version": "1.0.4",
@@ -1609,11 +2346,21 @@
       "version": "0.6.5",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/through2/-/through2-0.6.5.tgz",
       "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+      "requires": {
+        "readable-stream": "1.0.34",
+        "xtend": "4.0.1"
+      },
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         }
       }
     },
@@ -1632,6 +2379,9 @@
       "version": "2.0.2",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/topo/-/topo-2.0.2.tgz",
       "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+      "requires": {
+        "hoek": "4.1.1"
+      },
       "dependencies": {
         "hoek": {
           "version": "4.1.1",
@@ -1650,7 +2400,10 @@
       "version": "0.3.2",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
     },
     "type-detect": {
       "version": "1.0.0",
@@ -1669,6 +2422,11 @@
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "optional": true,
+      "requires": {
+        "source-map": "0.5.6",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      },
       "dependencies": {
         "source-map": {
           "version": "0.5.6",
@@ -1688,13 +2446,19 @@
       "version": "2.0.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/user-home/-/user-home-2.0.0.tgz",
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
     },
     "util": {
       "version": "0.10.3",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "dev": true,
+      "requires": {
+        "inherits": "2.0.1"
+      },
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
@@ -1712,19 +2476,33 @@
     "vinyl": {
       "version": "0.5.3",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/vinyl/-/vinyl-0.5.3.tgz",
-      "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4="
+      "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+      "requires": {
+        "clone": "1.0.2",
+        "clone-stats": "0.0.1",
+        "replace-ext": "0.0.1"
+      }
     },
     "vision": {
       "version": "4.1.1",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/vision/-/vision-4.1.1.tgz",
       "integrity": "sha1-4bYSstLi8gMQoDkpD9SdUSSPgto=",
       "dev": true,
+      "requires": {
+        "boom": "4.3.1",
+        "hoek": "4.1.1",
+        "items": "2.1.1",
+        "joi": "10.6.0"
+      },
       "dependencies": {
         "boom": {
           "version": "4.3.1",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/boom/-/boom-4.3.1.tgz",
           "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hoek": "4.1.1"
+          }
         },
         "hoek": {
           "version": "4.1.1",
@@ -1736,7 +2514,13 @@
           "version": "10.6.0",
           "resolved": "https://repository.cars.com/artifactory/api/npm/npm/joi/-/joi-10.6.0.tgz",
           "integrity": "sha1-Ulh/AtUri3XNsMdPCxZKGRoOH8I=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hoek": "4.1.1",
+            "isemail": "2.2.1",
+            "items": "2.1.1",
+            "topo": "2.0.2"
+          }
         }
       }
     },
@@ -1744,7 +2528,10 @@
       "version": "1.2.14",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
     },
     "window-size": {
       "version": "0.1.0",
@@ -1766,7 +2553,10 @@
       "version": "0.2.1",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
     },
     "xml-escape": {
       "version": "1.0.0",
@@ -1789,7 +2579,13 @@
       "version": "3.10.0",
       "resolved": "https://repository.cars.com/artifactory/api/npm/npm/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
+        "decamelize": "1.2.0",
+        "window-size": "0.1.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "bluebird": "^3.0.5",
     "boom": "3.0.0",
     "handlebars": "^4.0.5",
-    "hoek": "3.0.1",
     "iniparser": "^1.0.5",
     "inquirer": "^0.12.0",
     "joi": "7.0.0",


### PR DESCRIPTION
…threats.

This should probably be a minor version change so people don't have to edit their dep manually if they are using the `^` version sugar.